### PR TITLE
Fix hamburger menu and refactor its logic

### DIFF
--- a/assets/scripts/hamburger.js
+++ b/assets/scripts/hamburger.js
@@ -1,51 +1,17 @@
-const hamburger = document.querySelector('.hamburger__button');
-const nav = document.querySelector('.hamburger__drawer');
-const hamburgerActiv = document.querySelector('.hamburger__button--active');
-const navActiv = document.querySelector('.hamburger__drawer--active');
+const hamburgerButton = document.querySelector('.hamburger__button');
+const drawer = document.querySelector('.hamburger__drawer');
 
+const toggleHamburger = () => {
+  hamburgerButton.classList.toggle('hamburger__button--active');
+  drawer.classList.toggle('hamburger__drawer--active');
+};
 
-
-const handleClick = () => {
-  hamburger.classList.toggle('hamburger__button--active');
-  nav.classList.toggle('hamburger__drawer--active');
-}
-
-hamburger.addEventListener('click', handleClick);
-
-
-
-
-const removeClass = () => {
-  if (hamburger.classList.contains('hamburger__drawer--active')) {
-  hamburger.classList.remove('hamburger__button--active');
-  nav.classList.remove('hamburger__drawer--active');
+const hideDrawer = () => {
+  if (drawer.classList.contains('hamburger__drawer--active') && event.target !== hamburgerButton) {
+    hamburgerButton.classList.remove('hamburger__button--active');
+    drawer.classList.remove('hamburger__drawer--active');
   }
-}
+};
 
-document.addEventListener('click', removeClass);
-
-
-
-
-
-
-
-
-
-// const removeClass = () => {
-//   hamburger.classList.remove('hamburger__button--active');
-//   nav.classList.remove('hamburger__drawer--active');
-// }
-
-// if (hamburger.classList.contains('hamburger__button--active')) {
-//   document.addEventListener('click', removeClass);
-// }
-
-
-// const removeClass = () => {
-//   hamburger.classList.remove('hamburger__button--active');
-//   nav.classList.remove('hamburger__drawer--active');
-
-// document.addEventListener('click', () => {
-//   nav.display = 'none';
-// })
+hamburgerButton.addEventListener('click', toggleHamburger);
+document.addEventListener('click', hideDrawer);


### PR DESCRIPTION
Problem był w tym, że w IFie w `removeClass` sprawdzasz czy hamburger (czyli button) ma klasę `hamburger__drawer--active`, czyli klasę, którą się dodaję do drawera 😄 Tak jakby dwa osobne elementy porównywałeś

Dlatego ważne jest odpowiednie nazywanie zmiennych i funkcji żeby się nie mylić tak jak teraz, looknij jak ja to zrobiłem - np. `handleClick` nie mówi za wiele, jedynie że ta funkcja ma jakiś związek z kliknięciem, za to `toggleHamburger` już wprost mówi co robi dana funkcja. Tak samo `removeClass` za dużo nie mówi, bo nie wiadomo o jaką klasę chodzi, gdzie i po co ją usuwa, a `hideDrawer` już jest dość jasne.

A `event.target !== hamburgerButton` sprawdza czy targetem kliknięcia nie jest czasem hamburger button, bo inaczej działoby się to samo co bez tego ifa, czyli ta funkcja by usuwała klasę active od razu po jej dodaniu