### PR TITLE
Fix Hamburger Menu

### DIFF
--- a/assets/scripts/hamburger.js
+++ b/assets/scripts/hamburger.js
@@ -1,5 +1,4 @@
 const hamburgerButton = document.querySelector('.hamburger__button');
-const hamburgerButtonIcon = document.querySelector('hamburger__button-icon');
 const drawer = document.querySelector('.hamburger__drawer');
 
 const toggleHamburger = () => {
@@ -8,13 +7,12 @@ const toggleHamburger = () => {
 };
 
 const hideDrawer = () => {
-  if (drawer.classList.contains('hamburger__drawer--active') && event.target !== hamburgerButton) {
+  if (drawer.classList.contains('hamburger__drawer--active') && event.target !== hamburgerButton && !hamburgerButton.contains(event.target)) {
     hamburgerButton.classList.remove('hamburger__button--active');
     drawer.classList.remove('hamburger__drawer--active');
   }
 };
 
 hamburgerButton.addEventListener('click', toggleHamburger);
-hamburgerButtonIcon.addEventListener('click', toggleHamburger);
 
 document.addEventListener('click', hideDrawer);


### PR DESCRIPTION
To działa tak, że miałeś funkcję, która po kliknięciu na `hamburgerButton` dodaje odpowiednie klasy. Potem dodałeś funkcję `hideDrawer`, która po kliknięciu gdziekolwiek usuwa te klasy, co psuło `toggleHamburger`, bo zaraz po dodaniu `--active`, było usuwane.

Potem dodałem do `hideDrawer` IFa, który sprawdza czy kliknięto na `hamburgerButton`, jeśli tak, to ma się nie wywołać, czyli nie usuwać `--active`. Ale to sprawdzało tylko czy `event.target` to bezpośrednio `hamburgerButton`, przez co działało tylko przy kliknięciu między te "belki", bo belki to nie jest bezpośrednio `hamburgerButton` tylko jego child, dlatego dodałem też `&& !hamburgerButton.contains(event.target)`, dzięki czemu cały IF sprawdza czy kliknięto albo na samego `hamburgerButton`, albo na cokolwiek wewnątrz niego 😄 

A działało jak wyskakiwał błąd, bo dodałeś `querySelector` bez kropki oznaczającej że chodzi o klasę, czyli tak naprawdę ten `querySelector` nie wskazywał na żadne element, a mimo to próbowałeś na tym nieistniejącym elemencie użyć `addEventListener`, przez co wyskakiwał błąd.

A błąd sprawiał że funkcja `hideDrawer` przestawała zupełnie działać, czyli znowu po kliknięciu gdziekolwiek na `hamburgerButtona` otwierał się drawer tak jak kiedyś, ale za to nie zamykał się po kliknięciu gdziekolwiek 😛 